### PR TITLE
Remove unneeded streams from Theme YAML

### DIFF
--- a/grayscale.yaml
+++ b/grayscale.yaml
@@ -2,10 +2,3 @@ enabled: true
 color: blue
 dropdown:
   enabled: false
-
-streams:
-  scheme:
-    theme:
-      type: ReadOnlyStream
-      paths:
-        - user/themes/grayscale


### PR DESCRIPTION
These lines were in Antimatter and other themes, but they are useless now and break multisite
